### PR TITLE
Add setting `actionGroupExecuter.defaultShowActionSource`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following settings can be set and enter `ActionGroupExec: Execute Action Gro
 {
     "actionGroupExecuter.defaultProcessEndMessage": "\n\nStop of work!",
     "actionGroupExecuter.defaultFileAssociation": "log",
+    "actionGroupExecuter.defaultShowActionSource": false,
     "actionGroupExecuter.actionGroups": [
         {
             "name": "Example1",
@@ -231,9 +232,13 @@ The debug sessions `newConfiguration` and the `extendedOptions` for the terminal
 
 ## Extension Settings
 
-Execution groups can be added under the `actionGroupExecuter.actionGroups` setting. `actionGroupExecuter.defaultProcessEndMessage` can be used to define a user specific message that is displayed after the execution of a process which output is placed the file tab. With the `actionGroupExecuter.defaultFileAssociation` setting the display of the file tabs for process output can be configured.
+Execution groups can be added under the `actionGroupExecuter.actionGroups` setting. `actionGroupExecuter.defaultProcessEndMessage` can be used to define a user specific message that is displayed after the execution of a process which output is placed the file tab. With the `actionGroupExecuter.defaultFileAssociation` setting the display of the file tabs for process output can be configured. `actionGroupExecuter.defaultShowActionSource` can be used to toggle the visibility of the settings source.
 
 ## Release Notes
+
+### 0.0.15
+
+* Add setting `actionGroupExecuter.defaultShowActionSource` to toggle the visibility of the settings source.
 
 ### 0.0.14
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "action-group-executer",
     "displayName": "Action Group Executer",
     "description": "",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "keywords": [
         "terminal",
         "shell",
@@ -77,6 +77,11 @@
                         "type": "string",
                         "description": "Default file association of the tabs tabs spawned to display the process output.",
                         "default": "plaintext"
+                    },
+                    "actionGroupExecuter.defaultShowActionSource": {
+                        "type": "boolean",
+                        "description": "Toggle visibility of settings source.",
+                        "default": true
                     },
                     "actionGroupExecuter.actionGroups": {
                         "type": "array",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -319,20 +319,22 @@ export class ActionGroup implements vscode.QuickPickItem {
         config: EIActionGroup,
         defaultProcessEndMessage: string | undefined,
         defaultFileAssociation: string | undefined,
+        defaultShowActionSource: boolean | undefined,
         settingsSource: GroupSource
     ) {
         this.name = config.name;
-        this.label = this.name + " (" + settingsSource + ")";
-        const defaultProcessEndMessageAdj = defaultProcessEndMessage
-            ? defaultProcessEndMessage
-            : "";
-        const defaultFileAssociationAdj = defaultFileAssociation
-            ? defaultFileAssociation
-            : "";
+
+        const defaultProcessEndMessageAdj = defaultProcessEndMessage ?? "";
+        const defaultFileAssociationAdj = defaultFileAssociation ?? "";
+        const defaultShowActionSourceAdj = defaultShowActionSource ?? true;
 
         if (config.sortingIndex) {
             this.sortingIndex = config.sortingIndex;
         }
+        
+        this.label = (defaultShowActionSourceAdj)
+            ? this.name + " (" + settingsSource + ")"
+            : this.name;
 
         config.terminals?.forEach((terminalAction) => {
             const newTerminalAction = new TerminalAction(
@@ -563,7 +565,8 @@ class StringReplacer {
 function createAndMergeGroups(
     config: vscode.WorkspaceConfiguration,
     defaultProcessEndMessage: string | undefined,
-    defaultFileAssociation: string | undefined
+    defaultFileAssociation: string | undefined,
+    defaultShowActionSource: boolean | undefined
 ) {
     const inspect = config.inspect("actionGroups");
 
@@ -587,6 +590,7 @@ function createAndMergeGroups(
                     castedGroup,
                     defaultProcessEndMessage,
                     defaultFileAssociation,
+                    defaultShowActionSource,
                     source
                 );
                 mergedCommands.push(newGroup);
@@ -602,7 +606,7 @@ function createAndMergeGroups(
     // In that case we get all declarations doubled, that is actually not cool :/
     // The settings of the workspaceFolderValue are determined by the currently selected file. So we pick
     // workspaceValue over it, because you can have any file open and still get the setting. The other
-    // way around would mean that you won't get any group if a radom file outside the workspace is selected.
+    // way around would mean that you won't get any group if a random file outside the workspace is selected.
     if (vscode.workspace.workspaceFile) {
         createAndAddGroups(
             inspect?.workspaceFolderValue,
@@ -633,7 +637,8 @@ export function getActionGroups() {
     const commands = createAndMergeGroups(
         config,
         config.get<string>("defaultProcessEndMessage"),
-        config.get<string>("defaultFileAssociation")
+        config.get<string>("defaultFileAssociation"),
+        config.get<boolean>("defaultShowActionSource")
     );
 
     if (!commands) {


### PR DESCRIPTION
Add setting `actionGroupExecuter.defaultShowActionSource` to toggle the visibility of the settings source.